### PR TITLE
Modifications for Python 3.5 compatibility

### DIFF
--- a/statically.py
+++ b/statically.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 import warnings
 
 import cython
@@ -6,6 +7,10 @@ import cython
 
 __all__ = ["typed"]
 __version__ = "1.0a1"
+
+
+# async generators only present in Python 3.6+
+has_async_gen_fun = (3, 6) <= sys.version_info[:2]
 
 
 def _get_source_code(obj):
@@ -18,7 +23,7 @@ def _get_source_code(obj):
         extra_spaces = lines[0].find("@")
         return "".join(l[extra_spaces:] for l in lines[1:])
     else:
-        message = f"Function or class expected, got {type(obj).__name__}."
+        message = "Function or class expected, got {}.".format(type(obj).__name__)
         raise TypeError(message)
 
 
@@ -55,7 +60,7 @@ def typed(obj):
             two: int = 2
             return x + two
     """
-    if inspect.isasyncgenfunction(obj):
+    if has_async_gen_fun and inspect.isasyncgenfunction(obj):
         raise TypeError("Async generator funcions are not supported.")
     source = _get_source_code(obj)
     frame = inspect.currentframe().f_back

--- a/test_statically.py
+++ b/test_statically.py
@@ -1,5 +1,6 @@
 import unittest
 import asyncio
+import types
 
 import cython
 
@@ -9,6 +10,9 @@ import statically
 ONE_HUNDRED = 100
 execute = asyncio.get_event_loop().run_until_complete
 
+
+def is_cython_function(obj):
+    return 'cython_function_or_method' in str(type(obj))
 
 def anext(agen):
     gen = agen.asend(None)
@@ -24,6 +28,12 @@ class CompilationSuite(unittest.TestCase):
         def identity(x: cython.int):
             return x
         self.assertEqual(identity(14), 14)
+
+    def test_is_compiled(self):
+        @statically.typed
+        def compiled(x: cython.int):
+            return x
+        self.assertTrue(is_cython_function(compiled))
 
     def test_non_local_var_in_class(self):
         one = 1
@@ -94,12 +104,11 @@ class CompilationSuite(unittest.TestCase):
             return ONE_HUNDRED + x
         self.assertEqual(execute(add_one_hundred(5)), 105)
 
+    @unittest.skipUnless(statically.has_async_gen_fun, "Test does not apply for this version of Python")
     def test_async_generator(self):
         message = r"Async generator funcions are not supported."
         with self.assertRaisesRegex(TypeError, message):
-            @statically.typed
-            async def generator():
-                yield
+             from test_statically_async import generator
 
 
 if __name__ == '__main__':

--- a/test_statically.py
+++ b/test_statically.py
@@ -1,6 +1,5 @@
 import unittest
 import asyncio
-import types
 
 import cython
 

--- a/test_statically_async.py
+++ b/test_statically_async.py
@@ -1,0 +1,5 @@
+import statically
+
+@statically.typed
+async def generator():
+    yield


### PR DESCRIPTION
These code changes maintain functionality under 3.6, but also allow for compatibility under Python 3.5.

I also added a test to confirm that code is in fact compiling into cython.