### PR TITLE
README: add info that it works with IPython

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ pip install git+https://github.com/AlanCristhian/statically.git
 ## Caveats
 
 - Async generators are not supported.
-- Won't work with IDLE, neither with REPL.
+- Won't work with IDLE or REPL. Instead it works with [IPython shell](http://ipython.readthedocs.io/en/stable/)
 
 ## Contribute
 

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Caveats
 -------
 
 - Async generators are not supported.
-- Won't work with IDLE, neither with REPL.
+- Won't work with IDLE or REPL. Instead it works with `IPython shell <http://ipython.readthedocs.io/en/stable/>`
 
 Contribute
 ----------


### PR DESCRIPTION
Hey,

The project works fine with IPython, so lets inform people that it do so ;).

Proof below.

#### Standard Python shell 
```
$ python
Python 3.6.2 (default, Jul 20 2017, 03:52:27) 
[GCC 7.1.1 20170630] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cython, statically
>>> @statically.typed
... def sum_powers(x: cython.int, n: cython.int = 0):
...     return sum([x**n for n in range(1, x + 1)])
... 
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/home/dc/.virtualenvs/cytho/lib/python3.6/site-packages/statically.py", line 65, in typed
    source = _get_source_code(obj)
  File "/home/dc/.virtualenvs/cytho/lib/python3.6/site-packages/statically.py", line 22, in _get_source_code
    lines = inspect.getsourcelines(obj)[0]
  File "/usr/lib64/python3.6/inspect.py", line 952, in getsourcelines
    lines, lnum = findsource(object)
  File "/usr/lib64/python3.6/inspect.py", line 783, in findsource
    raise OSError('could not get source code')
OSError: could not get source code
>>> 
```

#### IPython
```
$ ipython3
/usr/lib/python3.6/site-packages/IPython/core/interactiveshell.py:724: UserWarning: Attempting to work in a virtualenv. If you encounter problems, please install IPython inside the virtualenv.
  warn("Attempting to work in a virtualenv. If you encounter problems, please "
-~= IPython interactive shell =~-
Defined pretty print function (pp) and libc (CDLL)

In [1]: import statically, cython

In [2]: >>> @statically.typed
   ...: ... def sum_powers(x: cython.int, n: cython.int = 0):
   ...: ...     return sum([x**n for n in range(1, x + 1)])
   ...: 

In [3]: sum_powers(5)
Out[3]: 3905
```