### PR TITLE
Add fallback for REPL to standard Python code

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ pip install git+https://github.com/AlanCristhian/statically.git
 ## Caveats
 
 - Async generators are not supported.
-- In contexts that doesn't have file - IDLE or REPL - will fallback to normal Python code. Works fine with [IPython](http://ipython.readthedocs.io/en/stable/).
+- In contexts that doesn't have file - IDLE or REPL - will fallback to normal Python code. Works fine with [IPython shell](http://ipython.readthedocs.io/en/stable/).
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ pip install git+https://github.com/AlanCristhian/statically.git
 ## Caveats
 
 - Async generators are not supported.
-- Won't work with IDLE, neither with REPL.
+- In contexts that doesn't have file - IDLE or REPL - will fallback to normal Python code. Works fine with [IPython](http://ipython.readthedocs.io/en/stable/).
 
 ## Contribute
 

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Caveats
 -------
 
 - Async generators are not supported.
-- Won't work with IDLE, neither with REPL.
+- In contexts that doesn't have file - IDLE or REPL - will fallback to normal Python code. Works fine with `IPython shell <http://ipython.readthedocs.io/en/stable/>`_.
 
 Contribute
 ----------

--- a/statically.py
+++ b/statically.py
@@ -13,6 +13,21 @@ __version__ = "1.0a2"
 has_async_gen_fun = (3, 6) <= sys.version_info[:2]
 
 
+def _can_cython_inline():
+    """Checks whether we are in a context which makes it possible to compile code inline with Cython.
+
+    Currently it is known that standard REPL and IDLE can't do that.
+    """
+    import __main__ as main
+
+    # statically works with IPython
+    if hasattr(main, 'get_ipython'):
+        return True
+
+    # standard REPL doesn't have __file__
+    return hasattr(main, '__file__')
+
+
 def _get_source_code(obj):
     if inspect.isclass(obj):
         lines = inspect.getsourcelines(obj)[0]
@@ -60,8 +75,11 @@ def typed(obj):
             two: int = 2
             return x + two
     """
-    if has_async_gen_fun and inspect.isasyncgenfunction(obj):
+    if not _can_cython_inline():
+        return obj
+    elif has_async_gen_fun and inspect.isasyncgenfunction(obj):
         raise TypeError("Async generator funcions are not supported.")
+
     source = _get_source_code(obj)
     frame = inspect.currentframe().f_back
     if inspect.isclass(obj):
@@ -73,3 +91,11 @@ def typed(obj):
         compiled = cython.inline(source, locals=locals_,
                                  globals=frame.f_globals, quiet=True)
         return compiled[obj.__name__]
+
+
+if not _can_cython_inline():
+    warnings.warn(
+        "Current code isn't launched from a file so statically.typed isn't able to cythonize stuff."
+        "Falling back to normal Python code.",
+        RuntimeWarning
+    )


### PR DESCRIPTION
Hey,

Thanks for such great project :).

This PR improves it a bit so that standard Python REPL works fine.

I have also extended README and included that statically works fine with IPython shell.

#### Side notes
1. I haven't check whether IDLE works, could you do that?
2. If we want to add a testcase for it - it probably should be done as a bash script that would do something similar as attached below.

```
(cytho) [dc@dc:statically|support-repl %]$ cat test.py
import cython
import statically

@statically.typed
def func():
    # Cython types are evaluated as for cdef declarations
    x: cython.int               # cdef int x
    y: cython.double = 0.57721  # cdef double y = 0.57721
    z: cython.float  = 0.57721  # cdef float z  = 0.57721

    # Python types shadow Cython types for compatibility reasons
    a: float = 0.54321          # cdef double a = 0.54321
    b: int = 5                  # cdef object b = 5
    c: long = 6                 # cdef object c = 6

    return y+z + a+b+c

@statically.typed
class A:
    a: cython.int
    b: cython.int
    def __init__(self, b=0):
        self.a = 3
        self.b = b

print('func = ', func())
a = A()
print(a.a, a.b)
(cytho) [dc@dc:statically|support-repl %]$ python -c "import test"
/home/dc/Projects/statically/statically.py:100: RuntimeWarning: Current code isn't launched from a file so statically.typed isn't able to cythonize stuff.Falling back to normal Python code.
  RuntimeWarning
func =  12.69763
3 0
(cytho) [dc@dc:statically|support-repl %]$ echo "import test" > a.py
(cytho) [dc@dc:statically|support-repl %]$ python a.py
func =  12.69763
3 0
(cytho) [dc@dc:statically|support-repl %]$ ipython -c "import test"
func =  12.69763
3 0
(cytho) [dc@dc:statically|support-repl %]$ ipython a.py
func =  12.69763
3 0
(cytho) [dc@dc:statically|support-repl %]$ 
```
